### PR TITLE
Add suport for named expandable args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "jf"
-version = "0.2.7"
+version = "0.3.0"
 dependencies = [
  "serde_json",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jf"
-version = "0.2.7"
+version = "0.3.0"
 edition = "2021"
 authors = ["Arijit Basu <hi@arijitbasu.in>"]
 description = 'A small utility to safely format and print JSON objects in the commandline'

--- a/README.md
+++ b/README.md
@@ -41,54 +41,58 @@ jf TEMPLATE [VALUE]... [NAME=VALUE]...
 
 Where TEMPLATE may contain the following placeholders:
 
-- `%q` for quoted and safely escaped JSON string.
-- `%s` for JSON values other than string.
-- `%v` for the `jf` version number.
-- `%%` for a literal `%` character.
+- `%q` quoted and safely escaped JSON string.
+- `%s` JSON values other than string.
+- `%v` the `jf` version number.
+- `%%` a literal `%` character.
 
 And [VALUE]... [NAME=VALUE]... are the values for the placeholders.
 
 ### SYNTAX
 
-- `%s`, `%q` for posiitonal placeholders.
-- `%(NAME)s`, `%(NAME)q` for named placeholders.
-- `%(NAME=DEFAULT)s`, `%(NAME=DEFAULT)q` for placeholders with default values.
-- `%?(NAME)s`, `%?(NAME)q` for optional placeholders.
-- `%*s`, `%*q` for variable number of array items.
-- `%**s`, `%**q` for variable number of key value pairs.
+- `%s`, `%q` posiitonal placeholder.
+- `%(NAME)s`, `%(NAME)q` named placeholder.
+- `%(NAME=DEFAULT)s`, `%(NAME=DEFAULT)q` placeholder with default value.
+- `%(NAME)?s`, `%(NAME)?q` placeholder with optional value.
+- `%*s`, `%*q` expand positional values as array items.
+- `%**s`, `%**q` expand positional values as key value pairs.
+- `%(NAME)*s`, `%(NAME)*q` expand named values as array items.
+- `%(NAME)**s`, `%(NAME)**q` expand positional values as key value pairs.
 
 ### RULES
 
 - Pass values for positional placeholders in the same order as in the template.
 - Pass values for named placeholders using `NAME=VALUE` syntax.
+- Pass values for named array items using `NAME=ITEM_N` syntax.
+- Pass values for named key value pairs using `NAME=KEY_N NAME=VALUE_N` syntax.
 - Optional placeholders default to empty string, which is considered as null.
 - Do not declare or pass positional placeholders or values after named ones.
-- Nesting placeholders is prohibited.
-- Variable length placeholder should be the last placeholder in a template.
+- Expandable positional placeholder should be the last placeholder in a template.
 
 ### EXAMPLES
 
 ```bash
-jf %s 1
-# 1
 
-jf %q 1
-# "1"
+  jf %s 1
+  # 1
 
-jf [%*s] 1 2 3
-# [1,2,3]
+  jf %q 1
+  # "1"
 
-jf {%**q} one 1 two 2 three 3
-# {"one":"1","two":"2","three":"3"}
+  jf [%*s] 1 2 3
+  # [1,2,3]
 
-jf "%q: %(value=default)q" foo value=bar
-# {"foo":"bar"}
+  jf {%**q} one 1 two 2 three 3
+  # {"one":"1","two":"2","three":"3"}
 
-jf "{str_or_bool: %?(str)q %?(bool)s, optional: %?(optional)q}" str=true
-# {"str_or_bool":"true","optional":null}
+  jf "{%q: %(value=default)q, %(bar)**q}" foo value=bar bar=biz bar=baz
+  # {"foo":"bar","biz":"baz"}
 
-jf '{1: %s, two: %q, 3: %(3)s, four: %(four=4)q, "%%": %(pct)q}' 1 2 3=3 pct=100%
-# {"1":1,"two":"2","3":3,"four":"4","%":"100%"}
+  jf "{str_or_bool: %(str)?q %(bool)?s, optional: %(optional)?q}" str=true
+  # {"str_or_bool":"true","optional":null}
+
+  jf '{1: %s, two: %q, 3: %(3)s, four: %(four=4)q, "%%": %(pct)q}' 1 2 3=3 pct=100%
+  # {"1":1,"two":"2","3":3,"four":"4","%":"100%"}
 ```
 
 #### Rust Library

--- a/assets/jf.1
+++ b/assets/jf.1
@@ -8,19 +8,19 @@ Where TEMPLATE may contain the following placeholders:
 .TP
 .B
 `%q`
-for quoted and safely escaped JSON string.
+quoted and safely escaped JSON string.
 .TP
 .B
 `%s`
-for JSON values other than string.
+JSON values other than string.
 .TP
 .B
 `%v`
-for the `jf` version number.
+the `jf` version number.
 .TP
 .B
 `%%`
-for a literal `%` character.
+a literal `%` character.
 .PP
 And [VALUE]\.\.\. [NAME=VALUE]\.\.\. are the values for the placeholders.
 .SH SYNTAX
@@ -28,24 +28,32 @@ And [VALUE]\.\.\. [NAME=VALUE]\.\.\. are the values for the placeholders.
 .TP
 .B
 `%s`, `%q`
-for posiitonal placeholders.
+posiitonal placeholder.
 .TP
 .B
 `%(NAME)s`, `%(NAME)q`
-for named placeholders.
-`%(NAME=DEFAULT)s`, `%(NAME=DEFAULT)q` for placeholders with default values.
+named placeholder.
+`%(NAME=DEFAULT)s`, `%(NAME=DEFAULT)q` placeholder with default value.
 .TP
 .B
-`%?(NAME)s`, `%?(NAME)q`
-for placeholders with optional values.
+`%(NAME)?s`, `%(NAME)?q`
+placeholder with optional value.
 .TP
 .B
 `%*s`, `%*q`
-for variable number of array items.
+expand positional values as array items.
 .TP
 .B
 `%**s`, `%**q`
-for variable number of key value pairs.
+expand positional values as key value pairs.
+.TP
+.B
+`%(NAME)*s`, `%(NAME)*q`
+expand named values as array items.
+.TP
+.B
+`%(NAME)**s`, `%(NAME)**q`
+expand positional values as key value pairs.
 .SH RULES
 
 .IP \(bu 3
@@ -53,32 +61,38 @@ Pass values for positional placeholders in the same order as in the template.
 .IP \(bu 3
 Pass values for named placeholders using `NAME=VALUE` syntax.
 .IP \(bu 3
+Pass values for named array items using `NAME=ITEM_N` syntax.
+.IP \(bu 3
+Pass values for named key value pairs using `NAME=KEY_N NAME=VALUE_N` syntax.
+.IP \(bu 3
 Optional placeholders default to empty string, which is considered as null.
 .IP \(bu 3
 Do not declare or pass positional placeholders or values after named ones.
 .IP \(bu 3
-Nesting placeholders is prohibited.
-.IP \(bu 3
-Variable length placeholder should be the last placeholder in a template.
+Expandable positional placeholder should be the last placeholder in a template.
 .SH EXAMPLES
 
-jf %s 1
-.SS  # 1
+$ jf %s 1
+.SS  - 1
 
-jf %q 1
-.SS  # "1"
+$ jf %q 1
+.SS  - "1"
 
-jf [%*s] 1 2 3
-.SS  # [1,2,3]
+$ jf [%*s] 1 2 3
+.SS  - [1,2,3]
 
-jf {%**q} one 1 two 2 three 3
-# {"one":"1","two":"2","three":"3"}
+$ jf {%**q} one 1 two 2 three 3
+.IP \(bu 3
+{"one":"1","two":"2","three":"3"}
 .PP
-jf "%q: %(value=default)q" foo value=bar
-# {"foo":"bar"}
+$ jf "{%q: %(value=default)q, %(bar)**q}" foo value=bar bar=biz bar=baz
+.IP \(bu 3
+{"foo":"bar","biz":"baz"}
 .PP
-jf "{str_or_bool: %?(str)q %?(bool)s, optional: %?(optional)q}" str=true
-# {"str_or_bool":"true","optional":null}
+$ jf "{str_or_bool: %(str)?q %(bool)?s, optional: %(optional)?q}" str=true
+.IP \(bu 3
+{"str_or_bool":"true","optional":null}
 .PP
-jf '{1: %s, two: %q, 3: %(3)s, four: %(four=4)q, "%%": %(pct)q}' 1 2 3=3 pct=100%
-# {"1":1,"two":"2","3":3,"four":"4","%":"100%"}
+$ jf '{1: %s, two: %q, 3: %(3)s, four: %(four=4)q, "%%": %(pct)q}' 1 2 3=3 pct=100%
+.IP \(bu 3
+{"1":1,"two":"2","3":3,"four":"4","%":"100%"}

--- a/assets/jf.txt
+++ b/assets/jf.txt
@@ -4,50 +4,53 @@ USAGE
 
   Where TEMPLATE may contain the following placeholders:
 
-  `%q`  for quoted and safely escaped JSON string.
-  `%s`  for JSON values other than string.
-  `%v`  for the `jf` version number.
-  `%%`  for a literal `%` character.
+  `%q`  quoted and safely escaped JSON string.
+  `%s`  JSON values other than string.
+  `%v`  the `jf` version number.
+  `%%`  a literal `%` character.
 
   And [VALUE]... [NAME=VALUE]... are the values for the placeholders.
 
 SYNTAX
 
-  `%s`, `%q`                             for posiitonal placeholders.
-  `%(NAME)s`, `%(NAME)q`                 for named placeholders.
-  `%(NAME=DEFAULT)s`, `%(NAME=DEFAULT)q` for placeholders with default values.
-  `%?(NAME)s`, `%?(NAME)q`               for placeholders with optional values.
-  `%*s`, `%*q`                           for variable number of array items.
-  `%**s`, `%**q`                         for variable number of key value pairs.
+  `%s`, `%q`                             posiitonal placeholder.
+  `%(NAME)s`, `%(NAME)q`                 named placeholder.
+  `%(NAME=DEFAULT)s`, `%(NAME=DEFAULT)q` placeholder with default value.
+  `%(NAME)?s`, `%(NAME)?q`               placeholder with optional value.
+  `%*s`, `%*q`                           expand positional values as array items.
+  `%**s`, `%**q`                         expand positional values as key value pairs.
+  `%(NAME)*s`, `%(NAME)*q`               expand named values as array items.
+  `%(NAME)**s`, `%(NAME)**q`             expand positional values as key value pairs.
 
 RULES
 
   * Pass values for positional placeholders in the same order as in the template.
   * Pass values for named placeholders using `NAME=VALUE` syntax.
+  * Pass values for named array items using `NAME=ITEM_N` syntax.
+  * Pass values for named key value pairs using `NAME=KEY_N NAME=VALUE_N` syntax.
   * Optional placeholders default to empty string, which is considered as null.
   * Do not declare or pass positional placeholders or values after named ones.
-  * Nesting placeholders is prohibited.
-  * Variable length placeholder should be the last placeholder in a template.
+  * Expandable positional placeholder should be the last placeholder in a template.
 
 EXAMPLES
 
-  jf %s 1
-  # 1
+  $ jf %s 1
+  - 1
 
-  jf %q 1
-  # "1"
+  $ jf %q 1
+  - "1"
 
-  jf [%*s] 1 2 3
-  # [1,2,3]
+  $ jf [%*s] 1 2 3
+  - [1,2,3]
 
-  jf {%**q} one 1 two 2 three 3
-  # {"one":"1","two":"2","three":"3"}
+  $ jf {%**q} one 1 two 2 three 3
+  - {"one":"1","two":"2","three":"3"}
 
-  jf "%q: %(value=default)q" foo value=bar
-  # {"foo":"bar"}
+  $ jf "{%q: %(value=default)q, %(bar)**q}" foo value=bar bar=biz bar=baz
+  - {"foo":"bar","biz":"baz"}
 
-  jf "{str_or_bool: %?(str)q %?(bool)s, optional: %?(optional)q}" str=true
-  # {"str_or_bool":"true","optional":null}
+  $ jf "{str_or_bool: %(str)?q %(bool)?s, optional: %(optional)?q}" str=true
+  - {"str_or_bool":"true","optional":null}
 
-  jf '{1: %s, two: %q, 3: %(3)s, four: %(four=4)q, "%%": %(pct)q}' 1 2 3=3 pct=100%
-  # {"1":1,"two":"2","3":3,"four":"4","%":"100%"}
+  $ jf '{1: %s, two: %q, 3: %(3)s, four: %(four=4)q, "%%": %(pct)q}' 1 2 3=3 pct=100%
+  - {"1":1,"two":"2","3":3,"four":"4","%":"100%"}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,53 +11,56 @@ USAGE
 
   Where TEMPLATE may contain the following placeholders:
 
-  `%q`  for quoted and safely escaped JSON string.
-  `%s`  for JSON values other than string.
-  `%v`  for the `jf` version number.
-  `%%`  for a literal `%` character.
+  `%q`  quoted and safely escaped JSON string.
+  `%s`  JSON values other than string.
+  `%v`  the `jf` version number.
+  `%%`  a literal `%` character.
 
   And [VALUE]... [NAME=VALUE]... are the values for the placeholders.
 
 SYNTAX
 
-  `%s`, `%q`                             for posiitonal placeholders.
-  `%(NAME)s`, `%(NAME)q`                 for named placeholders.
-  `%(NAME=DEFAULT)s`, `%(NAME=DEFAULT)q` for placeholders with default values.
-  `%?(NAME)s`, `%?(NAME)q`               for placeholders with optional values.
-  `%*s`, `%*q`                           for variable number of array items.
-  `%**s`, `%**q`                         for variable number of key value pairs.
+  `%s`, `%q`                             posiitonal placeholder.
+  `%(NAME)s`, `%(NAME)q`                 named placeholder.
+  `%(NAME=DEFAULT)s`, `%(NAME=DEFAULT)q` placeholder with default value.
+  `%(NAME)?s`, `%(NAME)?q`               placeholder with optional value.
+  `%*s`, `%*q`                           expand positional values as array items.
+  `%**s`, `%**q`                         expand positional values as key value pairs.
+  `%(NAME)*s`, `%(NAME)*q`               expand named values as array items.
+  `%(NAME)**s`, `%(NAME)**q`             expand positional values as key value pairs.
 
 RULES
 
   * Pass values for positional placeholders in the same order as in the template.
   * Pass values for named placeholders using `NAME=VALUE` syntax.
+  * Pass values for named array items using `NAME=ITEM_N` syntax.
+  * Pass values for named key value pairs using `NAME=KEY_N NAME=VALUE_N` syntax.
   * Optional placeholders default to empty string, which is considered as null.
   * Do not declare or pass positional placeholders or values after named ones.
-  * Nesting placeholders is prohibited.
-  * Variable length placeholder should be the last placeholder in a template.
+  * Expandable positional placeholder should be the last placeholder in a template.
 
 EXAMPLES
 
-  jf %s 1
-  # 1
+  $ jf %s 1
+  - 1
 
-  jf %q 1
-  # "1"
+  $ jf %q 1
+  - "1"
 
-  jf [%*s] 1 2 3
-  # [1,2,3]
+  $ jf [%*s] 1 2 3
+  - [1,2,3]
 
-  jf {%**q} one 1 two 2 three 3
-  # {"one":"1","two":"2","three":"3"}
+  $ jf {%**q} one 1 two 2 three 3
+  - {"one":"1","two":"2","three":"3"}
 
-  jf "%q: %(value=default)q" foo value=bar
-  # {"foo":"bar"}
+  $ jf "{%q: %(value=default)q, %(bar)**q}" foo value=bar bar=biz bar=baz
+  - {"foo":"bar","biz":"baz"}
 
-  jf "{str_or_bool: %?(str)q %?(bool)s, optional: %?(optional)q}" str=true
-  # {"str_or_bool":"true","optional":null}
+  $ jf "{str_or_bool: %(str)?q %(bool)?s, optional: %(optional)?q}" str=true
+  - {"str_or_bool":"true","optional":null}
 
-  jf '{1: %s, two: %q, 3: %(3)s, four: %(four=4)q, "%%": %(pct)q}' 1 2 3=3 pct=100%
-  # {"1":1,"two":"2","3":3,"four":"4","%":"100%"}
+  $ jf '{1: %s, two: %q, 3: %(3)s, four: %(four=4)q, "%%": %(pct)q}' 1 2 3=3 pct=100%
+  - {"1":1,"two":"2","3":3,"four":"4","%":"100%"}
 "#;
 
 #[derive(Debug)]
@@ -145,8 +148,7 @@ where
 fn read_named_placeholder<C>(
     val: &mut String,
     chars: &mut C,
-    named_placeholders: &HashMap<String, String>,
-    is_optional: bool,
+    named_values: &HashMap<String, Vec<String>>,
 ) -> Result<(), Error>
 where
     C: Iterator<Item = (usize, char)>,
@@ -156,6 +158,9 @@ where
     let mut last_char = None;
     let mut name = "".to_string();
     let mut default_value: Option<String> = None;
+    let mut is_optional = false;
+    let mut is_reading_expandable_items = false;
+    let mut is_reading_expandable_pairs = false;
 
     loop {
         let Some((col, ch)) = chars.next() else {
@@ -164,13 +169,26 @@ where
 
         match (ch, last_char) {
             ('=', _) => {
-                if is_optional {
-                    return Err(format!("optional placeholder '{name}' at column {col} cannot have a default value").as_str().into());
-                }
                 default_value = Some(read_default_value(chars));
                 last_char = Some(')');
             }
             (')', _) => {
+                last_char = Some(ch);
+            }
+            ('?', Some(')')) => {
+                if default_value.is_some() {
+                    return Err(format!("optional placeholder '{name}' at column {col} cannot have a default value").as_str().into());
+                }
+                is_optional = true;
+            }
+            ('*', Some(')')) => {
+                is_reading_expandable_items = true;
+                is_reading_expandable_pairs = false;
+                last_char = Some(ch);
+            }
+            ('*', Some('*')) => {
+                is_reading_expandable_pairs = true;
+                is_reading_expandable_items = false;
                 last_char = Some(ch);
             }
             (ch, Some(')')) if ch == 'q' || ch == 's' => {
@@ -179,8 +197,10 @@ where
                         .as_str()
                         .into());
                 }
-                let maybe_value =
-                    named_placeholders.get(&name).or(default_value.as_ref());
+                let maybe_value = named_values
+                    .get(&name)
+                    .and_then(|v| v.first())
+                    .or(default_value.as_ref());
 
                 if let Some(value) = maybe_value {
                     if ch == 'q' {
@@ -195,6 +215,35 @@ where
                     .as_str()
                     .into());
                 };
+                break;
+            }
+
+            (ch, Some('*')) if ch == 'q' || ch == 's' => {
+                if name.is_empty() {
+                    return Err(format!("placeholder missing name at column {col}")
+                        .as_str()
+                        .into());
+                }
+
+                if default_value.is_some() {
+                    return Err(format!("expandable placeholder '{name}' at column {col} cannot have a default value").as_str().into());
+                }
+
+                let mut args = named_values
+                    .get(&name)
+                    .cloned()
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(Into::into)
+                    .enumerate();
+
+                if is_reading_expandable_pairs {
+                    read_positional_pairs_placeholder(val, ch, col, &mut args)?;
+                } else if is_reading_expandable_items {
+                    read_positional_items_placeholder(val, ch, &mut args)?;
+                } else {
+                    unreachable!();
+                }
                 break;
             }
             (ch, None) if ch.is_alphanumeric() || ch == '_' => {
@@ -242,9 +291,9 @@ where
     Ok(())
 }
 
-fn collect_named_placeholders<'a, A>(
+fn collect_named_values<'a, A>(
     args: &mut A,
-    named_placeholders: &mut HashMap<String, String>,
+    named_values: &mut HashMap<String, Vec<String>>,
 ) -> Result<(), Error>
 where
     A: Iterator<Item = (usize, Cow<'a, str>)>,
@@ -253,12 +302,17 @@ where
         let Some((name, value)) = arg.split_once('=') else {
             return Err(format!("invalid syntax for value no. {valnum}, use 'NAME=VALUE' syntax").as_str().into());
         };
-        named_placeholders.insert(name.to_string(), value.to_string());
+
+        if let Some(values) = named_values.get_mut(name) {
+            values.push(value.to_string());
+        } else {
+            named_values.insert(name.to_string(), vec![value.to_string()]);
+        }
     }
     Ok(())
 }
 
-fn read_var_arr_placeholder<'a, A>(
+fn read_positional_items_placeholder<'a, A>(
     val: &mut String,
     ch: char,
     args: &mut A,
@@ -266,7 +320,9 @@ fn read_var_arr_placeholder<'a, A>(
 where
     A: Iterator<Item = (usize, Cow<'a, str>)>,
 {
+    let mut is_empty = true;
     for (_, arg) in args {
+        is_empty = false;
         if ch == 'q' {
             val.push_str(&json::to_string(&arg)?);
         } else {
@@ -275,13 +331,13 @@ where
         val.push(',');
     }
 
-    if !val.is_empty() {
+    if !is_empty {
         val.pop();
     }
     Ok(())
 }
 
-fn read_var_obj_placeholder<'a, A>(
+fn read_positional_pairs_placeholder<'a, A>(
     val: &mut String,
     ch: char,
     col: usize,
@@ -291,7 +347,9 @@ where
     A: Iterator<Item = (usize, Cow<'a, str>)>,
 {
     let mut is_reading_key = true;
+    let mut is_empty = true;
     for (_, arg) in args {
+        is_empty = false;
         let arg = if is_reading_key || ch == 'q' {
             json::to_string(&arg)?
         } else {
@@ -315,7 +373,7 @@ where
             .into());
     }
 
-    if !val.is_empty() {
+    if !is_empty {
         val.pop();
     }
     Ok(())
@@ -331,11 +389,10 @@ where
 {
     let mut val = "".to_string();
     let mut last_char = None;
-    let mut is_reading_named_placeholders = false;
-    let mut named_placeholders = HashMap::<String, String>::new();
-    let mut is_optional = false;
-    let mut is_reading_var_arr = false;
-    let mut is_reading_var_obj = false;
+    let mut is_reading_named_values = false;
+    let mut named_values = HashMap::<String, Vec<String>>::new();
+    let mut is_reading_positional_items = false;
+    let mut is_reading_positional_pairs = false;
 
     while let Some((col, ch)) = chars.next() {
         // Reading a named placeholder
@@ -348,15 +405,12 @@ where
             ('%', _) => {
                 last_char = Some(ch);
             }
-            ('?', Some('%')) => {
-                is_optional = true;
-            }
             ('v', Some('%')) => {
                 val.push_str(VERSION);
                 last_char = None;
             }
             (ch, Some('%')) | (ch, Some('*')) if ch == 's' || ch == 'q' => {
-                if is_reading_named_placeholders {
+                if is_reading_named_values {
                     return Err(
                         format!("positional placeholder '%{ch}' at column {col} was used after named placeholders, use named placeholder syntax '%(NAME){ch}' instead")
                         .as_str()
@@ -364,37 +418,32 @@ where
                     );
                 };
 
-                if is_reading_var_arr {
-                    read_var_arr_placeholder(&mut val, ch, args)?;
-                    is_reading_var_arr = false;
-                } else if is_reading_var_obj {
-                    read_var_obj_placeholder(&mut val, ch, col, args)?;
-                    is_reading_var_obj = false;
+                if is_reading_positional_items {
+                    read_positional_items_placeholder(&mut val, ch, args)?;
+                    is_reading_positional_items = false;
+                } else if is_reading_positional_pairs {
+                    read_positional_pairs_placeholder(&mut val, ch, col, args)?;
+                    is_reading_positional_pairs = false;
                 } else {
                     read_positional_placeholder(&mut val, ch, col, args)?;
                 }
                 last_char = None;
             }
             ('(', Some('%')) => {
-                if !is_reading_named_placeholders {
-                    is_reading_named_placeholders = true;
-                    collect_named_placeholders(args, &mut named_placeholders)?;
+                if !is_reading_named_values {
+                    is_reading_named_values = true;
+                    collect_named_values(args, &mut named_values)?;
                 };
-                read_named_placeholder(
-                    &mut val,
-                    chars,
-                    &named_placeholders,
-                    is_optional,
-                )?;
+                read_named_placeholder(&mut val, chars, &named_values)?;
                 last_char = None;
             }
             ('*', Some('%')) => {
-                is_reading_var_arr = true;
+                is_reading_positional_items = true;
                 last_char = Some(ch);
             }
-            ('*', Some('*')) if is_reading_var_arr => {
-                is_reading_var_arr = false;
-                is_reading_var_obj = true;
+            ('*', Some('*')) if is_reading_positional_items => {
+                is_reading_positional_items = false;
+                is_reading_positional_pairs = true;
                 last_char = Some(ch);
             }
             (_, Some('%')) => {
@@ -403,9 +452,8 @@ where
             (_, _) => {
                 val.push(ch);
                 last_char = None;
-                is_optional = false;
-                is_reading_var_arr = false;
-                is_reading_var_obj = false;
+                is_reading_positional_items = false;
+                is_reading_positional_pairs = false;
             }
         }
     }


### PR DESCRIPTION
- `%(NAME)*s`, `%(NAME)*q` expand named values as array items.
- `%(NAME)**s`, `%(NAME)**q` expand positional values as key value pairs.
- Pass values for named array items using `NAME=ITEM_N` syntax.
- Pass values for named key value pairs using `NAME=KEY_N NAME=VALUE_N` syntax.

Also, change the syntax for optional placeholder from `$?(...)` to `$(...)?`.