### PR TITLE
Add support for @FILE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "jf"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "serde_json",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jf"
-version = "0.3.3"
+version = "0.4.0"
 edition = "2021"
 authors = ["Arijit Basu <hi@arijitbasu.in>"]
 description = 'A small utility to safely format and print JSON objects in the commandline'

--- a/assets/jf.1
+++ b/assets/jf.1
@@ -2,7 +2,7 @@
 .TH jf  "1" "" ""
 .SH USAGE
 
-jf TEMPLATE [VALUE]\.\.\. [NAME=VALUE]\.\.\.
+jf TEMPLATE [VALUE]\.\.\. [NAME=VALUE]\.\.\. [NAME@FILE]\.\.\.
 .PP
 Where TEMPLATE may contain the following placeholders:
 .TP
@@ -22,25 +22,37 @@ the `jf` version number
 `%%`
 a literal `%` character
 .PP
-And [VALUE]\.\.\. [NAME=VALUE]\.\.\. are the values for the placeholders.
+And [VALUE]\.\.\. [NAME=VALUE]\.\.\. [NAME@FILE]\.\.\. are the values for the placeholders.
 .SH SYNTAX
 
 .TP
 .B
 `%s`
-`%q`                posiitonal placeholder
+`%q`                read positional argument
+.TP
+.B
+`%\fB-s\fP`
+`%\fB-q\fP`               read stdin
 .TP
 .B
 `%(NAME)s`
-`%(NAME)q`          named placeholder
+`%(NAME)q`          read named value from argument
 .TP
 .B
 `%(NAME=DEFAULT)s`
 `%(NAME=DEFAULT)q`  placeholder with default value
 .TP
 .B
+`%(NAME@FILE)s`
+`%(NAME@FILE)q`     read default value from file path
+.TP
+.B
+`%(NAME@-)s`
+`%(NAME@-)q`        read default value from stdin
+.TP
+.B
 `%(NAME?)s`
-`%(NAME?)q`         nullable placeholder that defaults to `null`
+`%(NAME?)q`         nullable placeholder that defaults to null
 .TP
 .B
 `%(NAME)?s`
@@ -48,29 +60,41 @@ And [VALUE]\.\.\. [NAME=VALUE]\.\.\. are the values for the placeholders.
 .TP
 .B
 `%*s`
-`%*q`               expand positional values as array items
+`%*q`               expand positional args as array items
+.TP
+.B
+`%*\fB-s\fP`
+`%*\fB-q\fP`              expand stdin as array items
 .TP
 .B
 `%**s`
-`%**q`              expand positional values as key value pairs
+`%**q`              expand positional args as key value pairs
+.TP
+.B
+`%**\fB-s\fP`
+`%**\fB-q\fP`             expand stdin as key value pairs
 .TP
 .B
 `%(NAME)*s`
-`%(NAME)*q`         expand named values as array items
+`%(NAME)*q`         expand named args as array items
 .TP
 .B
 `%(NAME)**s`
-`%(NAME)**q`        expand named values as key value pairs
+`%(NAME)**q`        expand named args as key value pairs
 .SH RULES
 
 .IP \(bu 3
 Pass values for positional placeholders in the same order as in the template.
+.IP \(bu 3
+Pass values to stdin following the order and separate them with null byte (`\0`).
 .IP \(bu 3
 Pass values for named placeholders using `NAME=VALUE` syntax.
 .IP \(bu 3
 Pass values for named array items using `NAME=ITEM_N` syntax.
 .IP \(bu 3
 Pass values for named key value pairs using `NAME=KEY_N NAME=VALUE_N` syntax.
+.IP \(bu 3
+Use `NAME@FILE` syntax to read from file where FILE can be `-` for stdin.
 .IP \(bu 3
 Do not declare or pass positional placeholders or values after named ones.
 .IP \(bu 3
@@ -86,13 +110,13 @@ Run: jf %q 1
 .IP \(bu 3
 Out: "1"
 .IP \(bu 3
-Run: jf [%*s] 1 2 3
-.IP \(bu 3
-Out: [1,2,3]
-.IP \(bu 3
-Run: jf {%**q} one 1 two 2 three 3
+Run: jf '{%**q}' one 1 two 2 three 3
 .IP \(bu 3
 Out: {"one":"1","two":"2","three":"3"}
+.IP \(bu 3
+Run: seq 1 3 | xargs printf '%s\0' | jf '[%*\fB-s\fP]'
+.IP \(bu 3
+Out: [1,2,3]
 .IP \(bu 3
 Run: jf "{%q: %(value=default)q, %(bar)**q}" foo value=bar bar=biz bar=baz
 .IP \(bu 3

--- a/src/usage.txt
+++ b/src/usage.txt
@@ -1,6 +1,6 @@
 USAGE
 
-  jf TEMPLATE [VALUE]... [NAME=VALUE]...
+  jf TEMPLATE [VALUE]... [NAME=VALUE]... [NAME@FILE]...
 
   Where TEMPLATE may contain the following placeholders:
 
@@ -9,26 +9,33 @@ USAGE
   `%v`  the `jf` version number
   `%%`  a literal `%` character
 
-  And [VALUE]... [NAME=VALUE]... are the values for the placeholders.
+  And [VALUE]... [NAME=VALUE]... [NAME@FILE]... are the values for the placeholders.
 
 SYNTAX
 
-  `%s`                `%q`                posiitonal placeholder
-  `%(NAME)s`          `%(NAME)q`          named placeholder
+  `%s`                `%q`                read positional argument
+  `%-s`               `%-q`               read stdin
+  `%(NAME)s`          `%(NAME)q`          read named value from argument
   `%(NAME=DEFAULT)s`  `%(NAME=DEFAULT)q`  placeholder with default value
-  `%(NAME?)s`         `%(NAME?)q`         nullable placeholder that defaults to `null`
+  `%(NAME@FILE)s`     `%(NAME@FILE)q`     read default value from file path
+  `%(NAME@-)s`        `%(NAME@-)q`        read default value from stdin
+  `%(NAME?)s`         `%(NAME?)q`         nullable placeholder that defaults to null
   `%(NAME)?s`         `%(NAME)?q`         optional placeholder that defaults to blank
-  `%*s`               `%*q`               expand positional values as array items
-  `%**s`              `%**q`              expand positional values as key value pairs
-  `%(NAME)*s`         `%(NAME)*q`         expand named values as array items
-  `%(NAME)**s`        `%(NAME)**q`        expand named values as key value pairs
+  `%*s`               `%*q`               expand positional args as array items
+  `%*-s`              `%*-q`              expand stdin as array items
+  `%**s`              `%**q`              expand positional args as key value pairs
+  `%**-s`             `%**-q`             expand stdin as key value pairs
+  `%(NAME)*s`         `%(NAME)*q`         expand named args as array items
+  `%(NAME)**s`        `%(NAME)**q`        expand named args as key value pairs
 
 RULES
 
   * Pass values for positional placeholders in the same order as in the template.
+  * Pass values to stdin following the order and separate them with null byte (`\0`).
   * Pass values for named placeholders using `NAME=VALUE` syntax.
   * Pass values for named array items using `NAME=ITEM_N` syntax.
   * Pass values for named key value pairs using `NAME=KEY_N NAME=VALUE_N` syntax.
+  * Use `NAME@FILE` syntax to read from file where FILE can be `-` for stdin.
   * Do not declare or pass positional placeholders or values after named ones.
   * Expandable positional placeholder should be the last placeholder in a template.
 
@@ -40,11 +47,11 @@ EXAMPLES
   - Run: jf %q 1
   - Out: "1"
 
-  - Run: jf [%*s] 1 2 3
-  - Out: [1,2,3]
-
-  - Run: jf {%**q} one 1 two 2 three 3
+  - Run: jf '{%**q}' one 1 two 2 three 3
   - Out: {"one":"1","two":"2","three":"3"}
+
+  - Run: seq 1 3 | xargs printf '%s\0' | jf '[%*-s]'
+  - Out: [1,2,3]
 
   - Run: jf "{%q: %(value=default)q, %(bar)**q}" foo value=bar bar=biz bar=baz
   - Out: {"foo":"bar","biz":"baz"}


### PR DESCRIPTION
- Use `%-s`, `%-q`, `%*-s`, `%*-q`, `%**-s`, `%**-q` syntax to read from stdin.
- Use `%(NAME@FILE)` syntax to read default value from file.
- Use `%(NAME@-)` syntax to read default value from stdin.
- Use `NAME@FILE` to pass default value for named placeholder from file.
- Use `NAME@-` to pass default value for named placeholder from stdin.
- Stdin values are separated by null (`\0`).