### PR TITLE
Allow smart merging via expansion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "jf"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "serde_json",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jf"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["Arijit Basu <hi@arijitbasu.in>"]
 description = 'A small utility to safely format and print JSON objects in the commandline'

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ And [VALUE]... [NAME=VALUE]... [NAME@FILE]... are the values for the placeholder
 - Pass values for named key value pairs using `NAME=KEY_N NAME=VALUE_N` syntax.
 - Use `NAME@FILE` syntax to read from file where FILE can be `-` for stdin.
 - Do not declare or pass positional placeholders or values after named ones.
-- Expandable positional placeholder should be the last placeholder in a template.
+- To allow merging arrays and objects via expansion, trailing comma after `s` and `q`
+  will be auto removed after the expansion if no value is passed for the placeholder.
 
 ### EXAMPLES
 

--- a/assets/jf.1
+++ b/assets/jf.1
@@ -98,7 +98,8 @@ Use `NAME@FILE` syntax to read from file where FILE can be `-` for stdin.
 .IP \(bu 3
 Do not declare or pass positional placeholders or values after named ones.
 .IP \(bu 3
-Expandable positional placeholder should be the last placeholder in a template.
+To allow merging arrays and objects via expansion, trailing comma after `s` and `q`
+will be auto removed after the expansion if no value is passed for the placeholder.
 .SH EXAMPLES
 
 .IP \(bu 3

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -95,6 +95,36 @@ fn test_format_expand_pairs_from_stdin() {
 }
 
 #[test]
+fn test_format_merge_arrays() {
+    let args = ["[%(a)*s, %(b)*s]"].map(Into::into);
+    assert_eq!(jf::format(args).unwrap(), "[]");
+
+    let args = ["[%(a)*s, %(b)*s]", "a=1", "a=2"].map(Into::into);
+    assert_eq!(jf::format(args).unwrap(), "[1,2]");
+
+    let args = ["[%(a)*s, %(b)*s]", "b=1", "b=2"].map(Into::into);
+    assert_eq!(jf::format(args).unwrap(), "[1,2]");
+
+    let args = ["[%(a)*s, %(b)*s]", "a=1", "b=2", "a=3", "b=4"].map(Into::into);
+    assert_eq!(jf::format(args).unwrap(), "[1,3,2,4]");
+}
+
+#[test]
+fn test_format_merge_objs() {
+    let args = ["{%(a)*s, %(b)*s}"].map(Into::into);
+    assert_eq!(jf::format(args).unwrap(), "{}");
+
+    let args = ["{%(a)**s, %(b)**s}", "a=1", "a=2"].map(Into::into);
+    assert_eq!(jf::format(args).unwrap(), r#"{"1":2}"#);
+
+    let args = ["{%(a)**s, %(b)**s}", "b=1", "b=2"].map(Into::into);
+    assert_eq!(jf::format(args).unwrap(), r#"{"1":2}"#);
+
+    let args = ["{%(a)**s, %(b)**s}", "a=1", "b=2", "a=3", "b=4"].map(Into::into);
+    assert_eq!(jf::format(args).unwrap(), r#"{"1":3,"2":4}"#);
+}
+
+#[test]
 fn test_format_named() {
     let args = [
         r#"{"1": %(1)s, one: %(1)q, "true": %(true)s, "truestr": %(true)q, foo: %(foo)s, bar: %(bar)q, esc: "%%"}"#,
@@ -646,14 +676,14 @@ fn test_usage_example() {
 #[test]
 fn test_print_version() {
     let arg = ["jf v%v"].map(Into::into);
-    assert_eq!(jf::format(arg).unwrap(), r#""jf v0.4.0""#);
+    assert_eq!(jf::format(arg).unwrap(), r#""jf v0.4.1""#);
 
     let args =
         ["{foo: %q, bar: %(bar)q, version: %v}", "foo", "bar=bar"].map(Into::into);
 
     assert_eq!(
         jf::format(args).unwrap(),
-        r#"{"foo":"foo","bar":"bar","version":"0.4.0"}"#
+        r#"{"foo":"foo","bar":"bar","version":"0.4.1"}"#
     );
 }
 

--- a/src/usage.txt
+++ b/src/usage.txt
@@ -37,7 +37,8 @@ RULES
   * Pass values for named key value pairs using `NAME=KEY_N NAME=VALUE_N` syntax.
   * Use `NAME@FILE` syntax to read from file where FILE can be `-` for stdin.
   * Do not declare or pass positional placeholders or values after named ones.
-  * Expandable positional placeholder should be the last placeholder in a template.
+  * To allow merging arrays and objects via expansion, trailing comma after `s` and `q`
+    will be auto removed after the expansion if no value is passed for the placeholder.
 
 EXAMPLES
 


### PR DESCRIPTION
To allow merging arrays and objects via expansion, trailing comma after `s` and `q` will be auto removed after the expansion if no value is passed for the placeholder.

Example:

```bash
jf "[%(a)*s, %(b)*s]" b=2 b=1
# [2,1]

jf "{%(a)**s, %(b)**s}" b=2 b=1
# {"2":1}
```