### PR TITLE
Add support for control placeholders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "jf"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "serde_json",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jf"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 authors = ["Arijit Basu <hi@arijitbasu.in>"]
 description = 'A small utility to safely format and print JSON objects in the commandline'

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ Where TEMPLATE may contain the following placeholders:
 - `%s` JSON values other than string
 - `%v` the `jf` version number
 - `%%` a literal `%` character
+- `%R` enable raw mode - render but do not format output
+- `%Y` enable pretty YAML mode - format output into pretty YAML
+- `%J` enable pretty JSON mode - format output into pretty JSON
 
 And [VALUE]... [NAME=VALUE]... [NAME@FILE]... are the values for the placeholders.
 

--- a/assets/jf.1
+++ b/assets/jf.1
@@ -21,6 +21,18 @@ the `jf` version number
 .B
 `%%`
 a literal `%` character
+.TP
+.B
+`%R`
+enable raw mode - render but do not format output
+.TP
+.B
+`%Y`
+enable pretty YAML mode - format output into pretty YAML
+.TP
+.B
+`%J`
+enable pretty JSON mode - format output into pretty JSON
 .PP
 And [VALUE]\.\.\. [NAME=VALUE]\.\.\. [NAME@FILE]\.\.\. are the values for the placeholders.
 .SH SYNTAX

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,3 @@
-#[cfg(test)]
-mod tests;
-
 fn main() {
     let args = std::env::args().skip(1).map(Into::into);
 

--- a/src/usage.txt
+++ b/src/usage.txt
@@ -8,6 +8,9 @@ USAGE
   `%s`  JSON values other than string
   `%v`  the `jf` version number
   `%%`  a literal `%` character
+  `%R`  enable raw mode - render but do not format output
+  `%Y`  enable pretty YAML mode - format output into pretty YAML
+  `%J`  enable pretty JSON mode - format output into pretty JSON
 
   And [VALUE]... [NAME=VALUE]... [NAME@FILE]... are the values for the placeholders.
 


### PR DESCRIPTION
- `%R` enable raw mode - render but do not format output
- `%Y` enable YAML mode - format output into YAML
- `%J` enable pretty JSON mode - format output into pretty JSON

Example:

```bash
jf "%R%*q" a b c
"a","b","c"

jf "%Y[%*q]" a b c
- a
- b
- c

jf "%J[%*q]" a b c
[
  "a",
  "b",
  "c"
]
```