### PR TITLE
Implement CLI options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "jf"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "serde_json",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jf"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2021"
 authors = ["Arijit Basu <hi@arijitbasu.in>"]
 description = 'A small utility to safely format and print JSON objects in the commandline'

--- a/assets/jf.1
+++ b/assets/jf.1
@@ -2,41 +2,41 @@
 .TH jf  "1" "" ""
 .SH USAGE
 
-jf TEMPLATE [VALUE]\.\.\. [NAME=VALUE]\.\.\. [NAME@FILE]\.\.\.
-.PP
-Where TEMPLATE may contain the following placeholders:
+jf [OPTION]\.\.\. [--] TEMPLATE [VALUE]\.\.\. [NAME=VALUE]\.\.\. [NAME@FILE]\.\.\.
+.SH OPTIONS
+
 .TP
 .B
-`%q`
-quoted and safely escaped JSON string
+\fB-r\fP, \fB--raw\fP
+output the raw rendered value without formatting
 .TP
 .B
-`%s`
-JSON values other than string
+\fB-p\fP, \fB--pretty\fP
+pretty print the output
 .TP
 .B
-`%v`
-the `jf` version number
+\fB-y\fP, \fB--yaml\fP
+output as YAML instead of JSON
+.TP
+.B
+\fB-h\fP, \fB--help\fP
+print this help message
+.TP
+.B
+\fB-v\fP, \fB--version\fP
+print the version number
+.TP
+.B
+--
+stop parsing options
+.SH TEMPLATE
+
+A template is a string that should render into valid YAML. It can contain the
+following placeholders:
 .TP
 .B
 `%%`
 a literal `%` character
-.TP
-.B
-`%R`
-enable raw mode - render but do not format output
-.TP
-.B
-`%Y`
-enable pretty YAML mode - format output into pretty YAML
-.TP
-.B
-`%J`
-enable pretty JSON mode - format output into pretty JSON
-.PP
-And [VALUE]\.\.\. [NAME=VALUE]\.\.\. [NAME@FILE]\.\.\. are the values for the placeholders.
-.SH SYNTAX
-
 .TP
 .B
 `%s`
@@ -93,12 +93,13 @@ And [VALUE]\.\.\. [NAME=VALUE]\.\.\. [NAME@FILE]\.\.\. are the values for the pl
 .B
 `%(NAME)**s`
 `%(NAME)**q`        expand named args as key value pairs
+.PP
+Use placeholders with suffix `q` for safely quoted JSON string and `s` for JSON values
+other than string.
 .SH RULES
 
 .IP \(bu 3
 Pass values for positional placeholders in the same order as in the template.
-.IP \(bu 3
-Pass values to stdin following the order and separate them with null byte (`\0`).
 .IP \(bu 3
 Pass values for named placeholders using `NAME=VALUE` syntax.
 .IP \(bu 3
@@ -106,12 +107,14 @@ Pass values for named array items using `NAME=ITEM_N` syntax.
 .IP \(bu 3
 Pass values for named key value pairs using `NAME=KEY_N NAME=VALUE_N` syntax.
 .IP \(bu 3
+Pass values to stdin following the order and separate them with null byte (`\0`).
+.IP \(bu 3
 Use `NAME@FILE` syntax to read from file where FILE can be `-` for stdin.
 .IP \(bu 3
-Do not declare or pass positional placeholders or values after named ones.
+Do not pass positional values after named values.
 .IP \(bu 3
-To allow merging arrays and objects via expansion, trailing comma after `s` and `q`
-will be auto removed after the expansion if no value is passed for the placeholder.
+To allow merging arrays and objects via expansion, trailing comma after `s` and `q`,
+if any, will be auto removed if no value is passed for the expandable placeholder.
 .SH EXAMPLES
 
 .IP \(bu 3

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,75 @@
-fn main() {
-    let args = std::env::args().skip(1).map(Into::into);
+use jf::VERSION;
+use std::env::Args;
+use std::iter::{Peekable, Skip};
 
-    match jf::format(args) {
+#[derive(Debug)]
+enum Format {
+    Raw,
+    Json,
+    PrettyJson,
+    Yaml,
+}
+
+#[derive(Debug)]
+enum Cli {
+    Help,
+    Version,
+    Format(Format, Peekable<Skip<Args>>),
+}
+
+impl Cli {
+    fn parse() -> Result<Self, jf::Error> {
+        let mut format = Format::Json;
+        let mut args = std::env::args().skip(1).peekable();
+
+        while let Some(arg) = args.peek() {
+            match arg.as_str() {
+                "-h" | "--help" => return Ok(Self::Help),
+                "-v" | "--version" => return Ok(Self::Version),
+                "-r" | "--raw" => {
+                    format = Format::Raw;
+                    args.next();
+                }
+                "-p" | "--pretty" => {
+                    format = Format::PrettyJson;
+                    args.next();
+                }
+                "-y" | "--yaml" => {
+                    format = Format::Yaml;
+                    args.next();
+                }
+
+                "--" => {
+                    args.next();
+                    break;
+                }
+                a if a.starts_with('-') => {
+                    return Err(format!("invalid argument {a}, try -h or --help")
+                        .as_str()
+                        .into())
+                }
+                _ => break,
+            }
+        }
+
+        Ok(Self::Format(format, args))
+    }
+}
+
+fn handle(cli: Cli) -> Result<String, jf::Error> {
+    match cli {
+        Cli::Help => Ok(jf::USAGE.into()),
+        Cli::Version => Ok(format!("jf {VERSION}")),
+        Cli::Format(Format::Raw, args) => jf::render(args.map(Into::into)),
+        Cli::Format(Format::Json, args) => jf::format(args.map(Into::into)),
+        Cli::Format(Format::PrettyJson, args) => jf::format_pretty(args.map(Into::into)),
+        Cli::Format(Format::Yaml, args) => jf::format_yaml(args.map(Into::into)),
+    }
+}
+
+fn main() {
+    let res = Cli::parse().and_then(handle);
+    match res {
         Ok(v) => println!("{v}"),
         Err(e) => {
             eprintln!("error: {e}");

--- a/src/usage.txt
+++ b/src/usage.txt
@@ -1,21 +1,22 @@
 USAGE
 
-  jf TEMPLATE [VALUE]... [NAME=VALUE]... [NAME@FILE]...
+  jf [OPTION]... [--] TEMPLATE [VALUE]... [NAME=VALUE]... [NAME@FILE]...
 
-  Where TEMPLATE may contain the following placeholders:
+OPTIONS
 
-  `%q`  quoted and safely escaped JSON string
-  `%s`  JSON values other than string
-  `%v`  the `jf` version number
-  `%%`  a literal `%` character
-  `%R`  enable raw mode - render but do not format output
-  `%Y`  enable pretty YAML mode - format output into pretty YAML
-  `%J`  enable pretty JSON mode - format output into pretty JSON
+  -r, --raw      output the raw rendered value without formatting
+  -p, --pretty   pretty print the output
+  -y, --yaml     output as YAML instead of JSON
+  -h, --help     print this help message
+  -v, --version  print the version number
+  --             stop parsing options
 
-  And [VALUE]... [NAME=VALUE]... [NAME@FILE]... are the values for the placeholders.
+TEMPLATE
 
-SYNTAX
+  A template is a string that should render into valid YAML. It can contain the
+  following placeholders:
 
+  `%%`                                    a literal `%` character
   `%s`                `%q`                read positional argument
   `%-s`               `%-q`               read stdin
   `%(NAME)s`          `%(NAME)q`          read named value from argument
@@ -31,17 +32,20 @@ SYNTAX
   `%(NAME)*s`         `%(NAME)*q`         expand named args as array items
   `%(NAME)**s`        `%(NAME)**q`        expand named args as key value pairs
 
+  Use placeholders with suffix `q` for safely quoted JSON string and `s` for JSON values
+  other than string.
+
 RULES
 
   * Pass values for positional placeholders in the same order as in the template.
-  * Pass values to stdin following the order and separate them with null byte (`\0`).
   * Pass values for named placeholders using `NAME=VALUE` syntax.
   * Pass values for named array items using `NAME=ITEM_N` syntax.
   * Pass values for named key value pairs using `NAME=KEY_N NAME=VALUE_N` syntax.
+  * Pass values to stdin following the order and separate them with null byte (`\0`).
   * Use `NAME@FILE` syntax to read from file where FILE can be `-` for stdin.
-  * Do not declare or pass positional placeholders or values after named ones.
-  * To allow merging arrays and objects via expansion, trailing comma after `s` and `q`
-    will be auto removed after the expansion if no value is passed for the placeholder.
+  * Do not pass positional values after named values.
+  * To allow merging arrays and objects via expansion, trailing comma after `s` and `q`,
+    if any, will be auto removed if no value is passed for the expandable placeholder.
 
 EXAMPLES
 


### PR DESCRIPTION
This adds:

-r, --raw      output the raw rendered value without formatting
-p, --pretty   pretty print the output
-y, --yaml     output as YAML instead of JSON
-h, --help     print this help message
-v, --version  print the version number
--             stop parsing options

And removes:

- `%v`
- `%R`
- `%Y`
- `%J`

Also the Rust library exposes more functions, each for different formatting options.